### PR TITLE
Prevent comments from being cropped out.

### DIFF
--- a/lib/pandoc_scratchblocks/scratch_template.html
+++ b/lib/pandoc_scratchblocks/scratch_template.html
@@ -13,6 +13,10 @@
                 #main pre {
                     display: table-row; width: 1px;
                 }
+
+            .comment div {
+                position: relative !important;
+            }
         </style>
         <title></title>
     </head>


### PR DESCRIPTION
This relates to #27, but I wasn’t exactly sure how to do that one (without diving into pandoc).

Instead, this just applies the fix in CodeClub/pandoc_scratchblocks#3 here.
