### PR TITLE
Allow searching for manifests in symlinked directories

### DIFF
--- a/build.py
+++ b/build.py
@@ -1075,15 +1075,11 @@ def get_path_to(root_dir, output_file):
 
 def find_files(dir, extension):
     manifests = []
-
-    def visit(m, dirname, names):
-        for n in names:
-            if n.endswith(extension):
-                m.append(os.path.join(dirname, n))
-
     for d in dir:
-        os.path.walk(d, visit, manifests)
-
+        for root, dirs, files in os.walk(d, followlinks=True):
+            for name in files:
+                if name.endswith(extension):
+                    manifests.append(os.path.join(root, name))
     return manifests
 
 def expand_glob(base_dir, paths, one_file=False):


### PR DESCRIPTION
This allows one to 'fake' the lessons directory by putting only
certain languages (or just one), and test builds on those only.
