### PR TITLE
[#59] Restrict height of screenshot in intro.

### DIFF
--- a/assets/css/master.min.css
+++ b/assets/css/master.min.css
@@ -206,14 +206,12 @@ td {
   font-weight: normal;
   font-style: normal;
 }
-
 @font-face {
   font-family: 'Comic Neue';
   src: url("../fonts/ComicNeue-Regular.eot");
   src: url("../fonts/ComicNeue-Regular.eot?#iefix") format("embedded-opentype"), url("../fonts/ComicNeue-Regular.woff") format("woff"), url("../fonts/ComicNeue-Regular.ttf") format("truetype");
   font-weight: 300;
 }
-
 @font-face {
   font-family: 'Comic Neue';
   src: url("../fonts/ComicNeue-Regular-Oblique.eot");
@@ -221,14 +219,12 @@ td {
   font-weight: 300;
   font-style: oblique;
 }
-
 @font-face {
   font-family: 'Comic Neue';
   src: url("../fonts/ComicNeue-Bold.eot");
   src: url("../fonts/ComicNeue-Bold.eot?#iefix") format("embedded-opentype"), url("../fonts/ComicNeue-Bold.woff") format("woff"), url("../fonts/ComicNeue-Bold.ttf") format("truetype");
   font-weight: 700;
 }
-
 @font-face {
   font-family: 'Comic Neue';
   src: url("../fonts/ComicNeue-Bold-Oblique.eot");
@@ -236,7 +232,6 @@ td {
   font-weight: 700;
   font-style: oblique;
 }
-
 .reset, figure {
   margin: 0;
   padding: 0;
@@ -352,7 +347,7 @@ body {
   min-height: 100%;
   min-width: 300px;
   position: relative;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  -webkit-tap-highlight-color: transparent;
 }
 
 a {
@@ -866,7 +861,7 @@ html[lang="en-GB"] .lesson-steps h1 b, html[lang="en-GB"] .lesson-steps h1 stron
 .lesson-steps section {
   margin-bottom: 1.5em;
 }
-.lesson-steps section#introduction {
+.lesson-steps section.intro {
   border-bottom: 3px dotted #f5a200;
 }
 .lesson-steps ol > li {

--- a/assets/css/phantomjs.min.css
+++ b/assets/css/phantomjs.min.css
@@ -97,14 +97,15 @@ body {
 .lesson-steps section {
   /* page-break-inside: avoid; */
 }
-.lesson-steps section#introduction {
+.lesson-steps section.intro {
   margin-left: 20px;
   margin-right: 20px;
   page-break-after: always;
   border-bottom: none;
 }
-.lesson-steps section#introduction img {
+.lesson-steps section.intro img {
   max-width: 440px;
+  max-height: 350px;
 }
 
 .level-indicator {

--- a/assets/css/wkhtmltopdf.min.css
+++ b/assets/css/wkhtmltopdf.min.css
@@ -98,14 +98,15 @@
   .lesson-steps section {
     /* page-break-inside: avoid; */
   }
-  .lesson-steps section#introduction {
+  .lesson-steps section.intro {
     margin-left: 20px;
     margin-right: 20px;
     page-break-after: always;
     border-bottom: none;
   }
-  .lesson-steps section#introduction img {
+  .lesson-steps section.intro img {
     max-width: 440px;
+    max-height: 350px;
   }
 
   .level-indicator {

--- a/assets/sass/module/_lesson-steps.scss
+++ b/assets/sass/module/_lesson-steps.scss
@@ -32,7 +32,7 @@
 	section {
 		margin-bottom: 1.5em;
 
-		&#introduction {
+		&.intro {
 			border-bottom: 3px dotted $color-warning;
 		}
 	}

--- a/assets/sass/pdf/module/_lesson-steps.scss
+++ b/assets/sass/pdf/module/_lesson-steps.scss
@@ -17,7 +17,7 @@
 		//	webkit doesn't recognise page-break-inside
 		/* page-break-inside: avoid; */
 
-		&#introduction {
+		&.intro {
 			margin-left:      20px;
 			margin-right:     20px;
 			page-break-after: always;
@@ -27,6 +27,7 @@
 			img {
 				//	Set max size on screenshot image
 				max-width:      440px;
+				max-height:     350px;
 			}
 		}
 	}


### PR DESCRIPTION
Also, avoid using `#introduction` as a selector, as it depends on the
introduction using the word “introduction” in its heading (which will
not be the case for translations.)

Refs #59.
