### PR TITLE
[#57] Prevent trailing blank pages in PDFs

### DIFF
--- a/assets/css/phantomjs.min.css
+++ b/assets/css/phantomjs.min.css
@@ -14,8 +14,9 @@ html {
 
 body {
   font-size: 90%;
-  margin: 0px 60px;
+  margin: 0 60px;
   padding-top: 27px;
+  padding-bottom: 0;
   max-width: 800px;
   width: inherit;
 }
@@ -106,6 +107,15 @@ body {
 .lesson-steps section.intro img {
   max-width: 440px;
   max-height: 350px;
+}
+.lesson-steps > section:last-child {
+  margin-bottom: 0;
+}
+.lesson-steps > section:last-child > section:last-child {
+  margin-bottom: 0;
+}
+.lesson-steps > section:last-child > section:last-child > :last-child {
+  margin-bottom: 0;
 }
 
 .level-indicator {

--- a/assets/css/wkhtmltopdf.min.css
+++ b/assets/css/wkhtmltopdf.min.css
@@ -15,8 +15,9 @@
 
   body {
     font-size: 90%;
-    margin: 0px 60px;
+    margin: 0 60px;
     padding-top: 27px;
+    padding-bottom: 0;
     max-width: 800px;
     width: inherit;
   }
@@ -107,6 +108,15 @@
   .lesson-steps section.intro img {
     max-width: 440px;
     max-height: 350px;
+  }
+  .lesson-steps > section:last-child {
+    margin-bottom: 0;
+  }
+  .lesson-steps > section:last-child > section:last-child {
+    margin-bottom: 0;
+  }
+  .lesson-steps > section:last-child > section:last-child > :last-child {
+    margin-bottom: 0;
   }
 
   .level-indicator {

--- a/assets/sass/pdf/base/_06-defaults.scss
+++ b/assets/sass/pdf/base/_06-defaults.scss
@@ -4,9 +4,10 @@ html {
 }
 
 body {
-	font-size:   90%;
-	margin:      0px 60px;
-	padding-top: 27px;
-	max-width:   800px;
-	width:       inherit;
+	font-size:      90%;
+	margin:         0 60px;
+	padding-top:    27px;
+	padding-bottom: 0;
+	max-width:      800px;
+	width:          inherit;
 }

--- a/assets/sass/pdf/module/_lesson-steps.scss
+++ b/assets/sass/pdf/module/_lesson-steps.scss
@@ -31,4 +31,17 @@
 			}
 		}
 	}
+
+  //	attempt to avoid blank last pages
+	> section:last-child {
+		margin-bottom: 0;
+
+		> section:last-child {
+			margin-bottom: 0;
+
+			> :last-child {
+				margin-bottom: 0;
+			}
+		}
+	}
 }


### PR DESCRIPTION
Remove bottom margin/padding from the final element of the document to
prevent a trailing blank page being generated.

Refs #57.
