### PR TITLE
Don’t auto-add the README.

### DIFF
--- a/assets/md/README.md
+++ b/assets/md/README.md
@@ -1,9 +1,0 @@
-# Code Club Projects
-
-## Contributors: Take note!
-
-This repository was \*auto-generated\* using the [Code Club Lesson Formatter](https://github.com/CodeClub/lesson_format). This repository exists to serve one of the [Code Club projects sites](http://projects.codeclub.org.uk) (via Github Pages).
-
-We :heart::heart::heart: your contributions, so __please do not create issues or pull requests against this auto-generated repository__. Instead, locate the source repository for the relevant curriculum (e.g. [python-curriculum](https://github.com/CodeClub/python-curriculum); [scratch-curriculum](https://github.com/CodeClub/scratch-curriculum)) and add your pull requests / issues there.
-
-## Thank you! :wink:

--- a/build.py
+++ b/build.py
@@ -798,7 +798,6 @@ def build(rebuild, lessons, theme, all_languages, output_dir):
     progress_print("Copying assets...")
 
     copydir(html_assets, output_dir)
-    copy_file(os.path.join(base, "assets", "md", "README.md"), output_dir)
 
     css_dir = os.path.join(output_dir, "css")
     js_dir  = os.path.join(output_dir, "js")


### PR DESCRIPTION
Auto-adding a static README is a bit unnecessary. Both repos already
contain a .gitignore and CNAME that are not auto-generated. It means a
fresh install won’t have the README, but never mind.
