### PR TITLE
Don’t copy unminified css to output.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,9 +67,7 @@ module.exports = function (grunt) {
       css: {
         files: '<%= css.any %>',
         tasks: [
-          'sass:dev',
-          'shell:css_uk',
-          'shell:css_world'
+          'sass:dev'
         ]
       }
     }
@@ -79,8 +77,6 @@ module.exports = function (grunt) {
 
   grunt.registerTask('default', [
     'sass:dev',
-    'shell:css_uk',
-    'shell:css_world',
     'watch'
   ]);
 


### PR DESCRIPTION
Just attempting to make this gruntfile consistent.

`sass:dev` builds unminified css. I don’t think we want this on the output (hence the `grunt build` task) so removing these shell tasks.
