### PR TITLE
Switch to using ddollar/heroku-buildpack-multi

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,3 @@
+https://github.com/heroku/heroku-buildpack-nodejs
+https://github.com/heroku/heroku-buildpack-ruby
+https://github.com/heroku/heroku-buildpack-python


### PR DESCRIPTION
https://github.com/andylolz/heroku-buildpack-python-extras appears to be broken now. Rather than fix it, it’s probably better to switch to use https://github.com/ddollar/heroku-buildpack-multi

Here are the steps to doing this:

 * run:

   ```
   heroku buildpacks:set https://github.com/ddollar/heroku-buildpack-multi.git
   ```

   …to use this new buildpack
 * merge this pull request (or pull it locally to test it, I guess)
 * push to heroku

NB The python buildpack [happens to run bin/post_compile](https://github.com/heroku/heroku-buildpack-python/blob/f507bb0c/bin/compile#L207-L210), which is really handy because lesson_format utilises this. So as long as the python buildpack is last in the .buildpacks file, this works (since bin/post_compile is dependent on stuff in the other two buildpacks). I am noting this here because it seems like something that could break in the future.

Fixes (well, hopefully) #178.